### PR TITLE
Support newer Vue and TypeScript

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,9 @@ Type safe state management inspired by Vuex.
 
 > This library includes many type level hacks. Use at your own risk.
 
+## Requirements
+Vue >= 2.2.6
+
 ## Examples
 
 ```ts

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "tslint": "^4.0.0",
     "tslint-config-ktsn": "^2.0.0",
     "typescript": "^2.1.4",
-    "vue": "^2.2.6",
+    "vue": "^2.2.0",
     "webpack": "^2.2.0",
     "webpack-espower-loader": "^1.0.1"
   },

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "tslint": "^4.0.0",
     "tslint-config-ktsn": "^2.0.0",
     "typescript": "^2.1.4",
-    "vue": "^2.1.10",
+    "vue": "^2.2.6",
     "webpack": "^2.2.0",
     "webpack-espower-loader": "^1.0.1"
   },

--- a/src/vue.ts
+++ b/src/vue.ts
@@ -1,4 +1,4 @@
-import * as Vue from 'vue'
+import Vue from 'vue'
 import { BG0, BM0, BA0 } from './core/base'
 import { Module, ModuleImpl } from './core/module'
 import { Store, StoreImpl, Subscriber } from './core/store'

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -1,4 +1,4 @@
-import Vue = require('vue')
+import Vue from 'vue'
 import { install } from '../src'
 
 Vue.use(install)

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -3,6 +3,12 @@ import { install } from '../src'
 
 Vue.use(install)
 
+// Since 2.2.0, Vue captures some errors by default.
+// We must override this behaviour because it prevents some tests with assert.throws().
+Vue.config.errorHandler = (err, vm, info) => {
+  throw err
+}
+
 declare module 'vue/types/vue' {
   interface Vue {
     $store: any

--- a/test/specs/hot-update.ts
+++ b/test/specs/hot-update.ts
@@ -1,6 +1,6 @@
 import assert = require('power-assert')
 import sinon = require('sinon')
-import Vue = require('vue')
+import Vue from 'vue'
 import { module, store, Getters, Mutations, Actions } from '../../src'
 
 describe('Hot Update', () => {

--- a/test/specs/vue.ts
+++ b/test/specs/vue.ts
@@ -4,9 +4,6 @@ import Vue from 'vue'
 import { module, store, Getters, Mutations } from '../../src'
 
 describe('Vue integration', () => {
-  Vue.config.errorHandler = (err, vm, info) => {
-      throw err
-  }
   it('has reactive state', () => {
     class FooState {
       value = 1

--- a/test/specs/vue.ts
+++ b/test/specs/vue.ts
@@ -1,9 +1,12 @@
 import assert = require('power-assert')
 import sinon = require('sinon')
-import Vue = require('vue')
+import Vue from 'vue'
 import { module, store, Getters, Mutations } from '../../src'
 
 describe('Vue integration', () => {
+  Vue.config.errorHandler = (err, vm, info) => {
+      throw err
+  }
   it('has reactive state', () => {
     class FooState {
       value = 1

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -13,6 +13,7 @@
     "noImplicitThis": true,
     "strictNullChecks": true,
     "suppressImplicitAnyIndexErrors": true,
-    "importHelpers": true
+    "importHelpers": true,
+    "allowSyntheticDefaultImports": true
   }
 }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -12,6 +12,7 @@
     "noImplicitReturns": true,
     "noImplicitThis": true,
     "strictNullChecks": true,
+    "noStrictGenericChecks": true,
     "suppressImplicitAnyIndexErrors": true,
     "importHelpers": true,
     "allowSyntheticDefaultImports": true


### PR DESCRIPTION
Current code can't be compiled by TS 2.4, and does not work with Vue >= 2.3

This PR *partially* fixes these problems.
(*partially* means, this PR just adds `--noStrictGenericChecks` instead of fixing type declarations)

Vue <= 2.2.6 is no longer supported if this PR is merged.