### PR TITLE
feat: add vuex plugin adapter

### DIFF
--- a/src/adapters/devtool-plugin.ts
+++ b/src/adapters/devtool-plugin.ts
@@ -1,7 +1,7 @@
-import { BA0, BG, BG0, BM0 } from './core/base'
+import { BA0, BG, BG0, BM0 } from '../core/base'
 
-import { Dictionary } from './utils'
-import { VueStore } from './vue'
+import { Dictionary } from '../utils'
+import { VueStore } from '../vue'
 
 const devtoolHook =
   typeof window !== 'undefined' &&

--- a/src/adapters/devtool-plugin.ts
+++ b/src/adapters/devtool-plugin.ts
@@ -2,6 +2,7 @@ import { BA0, BG, BG0, BM0 } from '../core/base'
 
 import { Dictionary } from '../utils'
 import { VueStore } from '../vue'
+import { flattenGetters } from './vuex'
 
 const devtoolHook =
   typeof window !== 'undefined' &&
@@ -35,30 +36,6 @@ function proxyStore (store: VueStore<{}, BG0, BM0, BA0>) {
     get state () {
       return store.state
     },
-    getters: flattenGetters(store.getters)
+    getters: flattenGetters(store.getters, '.')
   }
-}
-
-function flattenGetters (getters: BG0): Dictionary<any> {
-  function loop (acc: Dictionary<any>, path: string[], getters: BG0): Dictionary<any> {
-    Object.keys(getters).forEach(key => {
-      if (key === '__proxy__' || key === 'modules') {
-        return
-      }
-
-      const desc = Object.getOwnPropertyDescriptor(getters, key)
-      if (!(getters[key].__proto__ instanceof BG)) {
-        Object.defineProperty(acc, path.concat(key).join('.'), {
-          get: () => getters[key],
-          enumerable: true,
-          configurable: true
-        })
-      }
-      else {
-        loop(acc, path.concat(key), getters[key])
-      }
-    })
-    return acc
-  }
-  return loop({}, [], getters)
 }

--- a/src/adapters/vuex.ts
+++ b/src/adapters/vuex.ts
@@ -1,0 +1,146 @@
+import { WatchOptions } from 'vue'
+import { Plugin } from '../vue'
+import { BG0, BG, BA0, BM0 } from '../core/base'
+import { Dictionary, isPromise } from '../utils'
+
+/**
+ * We cannot use original Vuex typings because
+ * they conficts Sinai's type augmentation for ComponentOptions
+ */
+interface VuexStore<S> {
+  readonly state: S
+  readonly getters: any
+
+  replaceState(state: S): void
+
+  dispatch: Dispatch
+  commit: Commit
+
+  subscribe(fn: (mutation: MutationPayload, state: S) => any): () => void
+  watch<T>(getter: (state: S, getters: any) => T, cb: (value: T, oldValue: T) => void, options?: WatchOptions): () => void
+
+  registerModule(...args: any[]): void
+  unregisterModule(...args: any[]): void
+}
+
+interface Payload {
+  type: string
+}
+
+interface MutationPayload extends Payload {
+  payload: any
+}
+
+interface Dispatch {
+  (type: string, payload?: any): Promise<any>
+  <P extends Payload>(payloadWithType: P): Promise<any>
+}
+
+interface Commit {
+  (type: string, payload?: any): void
+  <P extends Payload>(payloadWithType: P): void
+}
+
+/**
+ * Convert Vuex plugin to Sinai plugin
+ */
+export function convertVuexPlugin<S, G extends BG0, M extends BM0, A extends BA0>(
+  plugin: (store: any) => void
+): Plugin<S, G, M, A> {
+  return store => {
+    const storeAdapter: VuexStore<any> = {
+      get state() {
+        return store.state
+      },
+
+      get getters() {
+        return flattenGetters(store.getters, '/')
+      },
+
+      replaceState(state) {
+        store.replaceState(state)
+      },
+
+      dispatch<P extends Payload>(type: string | P, payload?: any): Promise<any> {
+        if (typeof type !== 'string') {
+          payload = type
+          type = payload.type as string
+        }
+        const path = type.split('/')
+        const action = path.reduce((action, key) => {
+          return action[key]
+        }, store.actions)
+
+        const res = action(payload)
+        if (isPromise(res)) {
+          return res
+        } else {
+          return Promise.resolve(res)
+        }
+      },
+
+      commit<P extends Payload>(type: string | P, payload?: any): void {
+        if (typeof type !== 'string') {
+          payload = type
+          type = payload.type as string
+        }
+        const path = type.split('/')
+        const mutation = path.reduce((mutation, key) => {
+          return mutation[key]
+        }, store.mutations)
+
+        mutation(payload)
+      },
+
+      subscribe(fn) {
+        return store.subscribe((path, payload, state) => {
+          const type = path.join('/')
+          fn({
+            type,
+            payload: payload[0]
+          }, state)
+        })
+      },
+
+      watch(getter, cb, options) {
+        return store.watch(
+          () => getter(this.state, this.getters),
+          cb,
+          options
+        )
+      },
+
+      registerModule() {
+        throw new Error('[sinai:vuex-plugin-adapter] registerModule is not supported')
+      },
+
+      unregisterModule() {
+        throw new Error('[sinai:vuex-plugin-adapter] unregisterModule is not supported')
+      }
+    }
+    plugin(storeAdapter)
+  }
+}
+
+export function flattenGetters (getters: BG0, sep: string): Dictionary<any> {
+  function loop (acc: Dictionary<any>, path: string[], getters: BG0): Dictionary<any> {
+    Object.keys(getters).forEach(key => {
+      if (key === '__proxy__' || key === 'modules') {
+        return
+      }
+
+      const desc = Object.getOwnPropertyDescriptor(getters, key)
+      if (!(getters[key].__proto__ instanceof BG)) {
+        Object.defineProperty(acc, path.concat(key).join(sep), {
+          get: () => getters[key],
+          enumerable: true,
+          configurable: true
+        })
+      } else {
+        loop(acc, path.concat(key), getters[key])
+      }
+    })
+    return acc
+  }
+  return loop({}, [], getters)
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
 export { module } from './core/module'
 export { inject, Getters, Mutations, Actions } from './core/base'
+export { convertVuexPlugin } from './adapters/vuex'
 export { store, install } from './vue'

--- a/src/vue.ts
+++ b/src/vue.ts
@@ -2,7 +2,7 @@ import Vue from 'vue'
 import { BG0, BM0, BA0 } from './core/base'
 import { Module, ModuleImpl } from './core/module'
 import { Store, StoreImpl, Subscriber } from './core/store'
-import { devtoolPlugin } from './devtool-plugin'
+import { devtoolPlugin } from './adapters/devtool-plugin'
 import { Dictionary, assert, bind } from './utils'
 
 let _Vue: typeof Vue

--- a/test/specs/vuex-plugin-adapter.ts
+++ b/test/specs/vuex-plugin-adapter.ts
@@ -1,0 +1,138 @@
+import * as assert from 'power-assert'
+import { convertVuexPlugin } from '../../src/adapters/vuex'
+import { store, module, Getters, Actions, Mutations } from '../../src/index'
+
+describe('Vuex Plugin Adapter', () => {
+  class FooState {
+    value = 'bar'
+  }
+
+  class FooGetters extends Getters<FooState>() {
+    get testGetter() {
+      return this.state.value + 'foo'
+    }
+  }
+
+  class FooMutations extends Mutations<FooState>() {
+    testMutation(str: string) {
+      this.state.value += ' ' + str
+    }
+  }
+
+  class FooActions extends Actions<FooState, FooGetters, FooMutations>() {
+    testAction(str: string) {
+      this.mutations.testMutation(str)
+    }
+
+    objAction(payload: { str: string }) {
+      this.mutations.testMutation(payload.str)
+    }
+  }
+
+  const foo = module({
+    state: FooState,
+    getters: FooGetters,
+    mutations: FooMutations,
+    actions: FooActions
+  })
+
+  it('returns store state', done => {
+    function vuexPlugin(store: any) {
+      assert.deepStrictEqual(store.state, new FooState())
+      done()
+    }
+
+    store(foo, {
+      plugins: [convertVuexPlugin(vuexPlugin)]
+    })
+  })
+
+  it('returns flatten getters', done => {
+    function vuexPlugin(store: any) {
+      assert.deepStrictEqual(store.getters, {
+        'foo/testGetter': 'barfoo'
+      })
+      done()
+    }
+
+    store(module().child('foo', foo), {
+      plugins: [convertVuexPlugin(vuexPlugin)]
+    })
+  })
+
+  it('dispatches actions', done => {
+    function vuexPlugin(store: any) {
+      store.dispatch('foo/testAction', 'action')
+      assert(store.state.foo.value === 'bar action')
+      done()
+    }
+
+    store(module().child('foo', foo), {
+      plugins: [convertVuexPlugin(vuexPlugin)]
+    })
+  })
+
+  it('dispatches object type dispatch', done => {
+    function vuexPlugin(store: any) {
+      store.dispatch({
+        type: 'foo/objAction',
+        str: 'object action'
+      })
+      assert(store.state.foo.value === 'bar object action')
+      done()
+    }
+
+    store(module().child('foo', foo), {
+      plugins: [convertVuexPlugin(vuexPlugin)]
+    })
+  })
+
+  it('commits mutations', done => {
+    function vuexPlugin(store: any) {
+      store.commit('foo/testMutation', 'mutation')
+      assert(store.state.foo.value === 'bar mutation')
+      done()
+    }
+
+    store(module().child('foo', foo), {
+      plugins: [convertVuexPlugin(vuexPlugin)]
+    })
+  })
+
+  it('subscribes store mutation', done => {
+    function vuexPlugin(store: any) {
+      store.subscribe((mutation: any, state: any) => {
+        assert.deepStrictEqual(mutation, {
+          type: 'testMutation',
+          payload: 'mutation'
+        })
+
+        assert.deepStrictEqual(state, s.state)
+        done()
+      })
+    }
+
+    const s = store(foo, {
+      plugins: [convertVuexPlugin(vuexPlugin)]
+    })
+    s.mutations.testMutation('mutation')
+  })
+
+  it('watches state change', done => {
+    function vuexPlugin(store: any) {
+      store.watch(
+        (state: FooState) => state.value,
+        (newState: string, oldState: string) => {
+          assert(newState === 'test')
+          assert(oldState === 'bar')
+          done()
+        }
+      )
+    }
+
+    const s = store(foo, {
+      plugins: [convertVuexPlugin(vuexPlugin)]
+    })
+    s.state.value = 'test'
+  })
+})


### PR DESCRIPTION
related #13 

This PR adds `convertVuexPlugin` function which converts a Vuex plugin to Sinai plugin. It creates Vuex store adapter having the same interface as Vuex store and translates all procedures to it for Sinai store.

Note that all sinai modules are treated as namespaced module in Vuex, so getters/dispatch/commit will be translated with the following rules:

\                | Sinai                                                         | Vuex
----------|----------------------------------------|--------------------------------------
getters    | `getters.path.to.getter`                           | `getters['path/to/getter']`
actions    | `actions.path.to.action(payload)`           | `dispatch('path/to/action', payload)`
mutations | `mutations.path.to.mutation(payload)` | `commit('path/to/mutation', payload)`

### Examples

I highly recommend always use named import (`import { store } from 'sinai'`) than namespaced import (`import * as Sinai from 'sinai'`) when you use `esm` build. Because the latter will includes all source code of Sinai even if you do not use the vuex plugin adapter.

#### Create Sinai plugin from Vuex plugin

```ts
import { store, convertVuexPlugin } from 'sinai'
import vuexPlugin from 'some-vuex-plugin'
import rootModule from './module'

const s = store(rootModule, {
  plugins: [
    convertVuexPlugin(vuexPlugin)
  ]
})
```
