### PR TITLE
fix: improve test util types

### DIFF
--- a/test/specs/test.ts
+++ b/test/specs/test.ts
@@ -134,7 +134,7 @@ describe('Testing utility', () => {
         computed: () => 100
       },
       mutations: {
-        inc: spy as Function
+        inc: spy as never
       }
     })
     actions.test()
@@ -185,8 +185,8 @@ describe('Testing utility', () => {
         foo: {
           state: { value: 100 },
           getters: { test: 200 },
-          mutations: { test: mutationSpy as Function },
-          actions: { test: actionSpy as Function }
+          mutations: { test: mutationSpy as never },
+          actions: { test: actionSpy as never }
         }
       }
     })


### PR DESCRIPTION
This makes test utility have more proper types. It let editors provide more accurate completion for the 2nd argument of `stub` function.